### PR TITLE
clear keys list as well when the widget updates otherwise RangeError …

### DIFF
--- a/lib/src/core/expansion_tile_group.dart
+++ b/lib/src/core/expansion_tile_group.dart
@@ -45,6 +45,9 @@ class _ExpansionTileGroupState extends State<ExpansionTileGroup> {
 
   @override
   void didUpdateWidget(ExpansionTileGroup oldWidget) {
+    expansionTileKeys.clear();
+    expansionTileKeys.addAll(List.generate(widget.children.length,
+        (index) => widget.children[index].expansionKey ?? GlobalKey()));
     expansionChildren.clear();
     expansionChildren.addAll(List.generate(
         widget.children.length,


### PR DESCRIPTION
…occurs when number of items change in the list. 

This occurs when list grows.