### PR TITLE
Title and subtitle overflow fix

### DIFF
--- a/lib/src/core/expansion_tile_custom.dart
+++ b/lib/src/core/expansion_tile_custom.dart
@@ -551,20 +551,22 @@ class ExpansionTileCustomState extends State<ExpansionTileCustom>
                         widget.leading ??
                             _buildLeadingIcon(context) ??
                             const SizedBox.shrink(),
-                        Column(
-                          children: [
-                            Padding(
-                              padding: widget.tilePadding ??
-                                  expansionTileTheme.tilePadding ??
-                                  const EdgeInsets.symmetric(horizontal: 8),
-                              child: DefaultTextStyle(
-                                  style: TextStyle(color: _headerColor.value),
-                                  child: widget.title),
-                            ),
-                            widget.subtitle ?? const SizedBox.shrink(),
-                          ],
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Padding(
+                                padding: widget.tilePadding ??
+                                    expansionTileTheme.tilePadding ??
+                                    const EdgeInsets.symmetric(horizontal: 8),
+                                child: DefaultTextStyle(
+                                    style: TextStyle(color: _headerColor.value),
+                                    child: widget.title),
+                              ),
+                              widget.subtitle ?? const SizedBox.shrink(),
+                            ],
+                          ),
                         ),
-                        const Spacer(),
                         widget.isHasTrailing == true
                             ? widget.trailing ??
                                 _buildTrailingIcon(context) ??


### PR DESCRIPTION
I've noticed an issue with horizontal overflow when using `isDefaultVerticalPadding = false`:
![image](https://github.com/congthanhng/Expansion-Tile-Group/assets/51935943/8fa88d01-4f77-429d-b3f9-850ef7585cad)

This PR fixes overflow issue by wrapping title and subtitle column in `Expanded`:
![image](https://github.com/congthanhng/Expansion-Tile-Group/assets/51935943/8f668256-35a6-4623-9de6-eed250c14f45)
